### PR TITLE
Make jest a devDependency instead of a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/leahciMic/uuid-v4/issues"
   },
-  "dependencies": {
+  "devDependencies": {
     "jest": "^23.1.0"
   }
 }


### PR DESCRIPTION
This saves people from having to download a ton of other dependencies when they use this library